### PR TITLE
Dynamically set the HTTP timeout to half the polling interval

### DIFF
--- a/src/eachwatt.ts
+++ b/src/eachwatt.ts
@@ -9,6 +9,7 @@ import { WebSocketPublisherImpl } from './publisher/websocket'
 import { PublisherType } from './publisher'
 import { pollCharacteristicsSensors } from './characteristics'
 import { createLogger } from './logger'
+import { setRequestTimeout } from './http/client'
 
 // Set up a signal handler, so we can exit on Ctrl + C when run from Docker
 process.on('SIGINT', () => {
@@ -100,9 +101,12 @@ const mainPollerFunc = async (config: Config) => {
     publisherImpl: webSocketServer,
   })
 
-  // Start polling sensors
+  // Adjust the HTTP timeout to be half that of the polling interval
   const pollingInterval = config.settings.pollingInterval
   logger.info(`Polling sensors with interval ${pollingInterval} milliseconds`)
+  setRequestTimeout((pollingInterval as number) / 2)
+
+  // Start polling sensors
   await mainPollerFunc(config)
   setInterval(mainPollerFunc, pollingInterval, config)
 })()

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,14 +1,21 @@
 import axios, { AxiosResponse } from 'axios'
 import http from 'http'
+import { createLogger } from '../logger'
+
+const logger = createLogger('http')
 
 const httpClient = axios.create({
   // We keep polling the same hosts over and over so keep-alive is essential
   httpAgent: new http.Agent({ keepAlive: true }),
-  timeout: 1000,
 })
 
 let lastTimestamp = 0
 const promiseCache = new Map()
+
+export const setRequestTimeout = (timeoutMs: number) => {
+  httpClient.defaults.timeout = timeoutMs
+  logger.info(`Using ${timeoutMs} millisecond timeout for HTTP requests`)
+}
 
 export const getDedupedResponse = async (timestamp: number, url: string): Promise<AxiosResponse> => {
   // Clear the cache whenever the timestamp changes


### PR DESCRIPTION
The previous default of 1000 milliseconds can be too low for low signal-strength wifi sensors, which sporadically take a long time to respond.

Closes #40